### PR TITLE
Reverse order course id for course list fixes #5.

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -312,7 +312,7 @@ class quizaccess_sebserver_external extends external_api {
         }
         $csql = 'select id, shortname, fullname, idnumber,
                startdate, enddate, visible, timecreated, timemodified
-               from {course} ' . $sqlconditions;
+               from {course} ' . $sqlconditions . ' ORDER BY id DESC';
 
         $cparams = array();
         $courses = $DB->get_records_sql($csql, $cparams, $startneedle, $perpage);


### PR DESCRIPTION
I'm currently waiting a lot for the list of exams to populate.
This fix makes sure the exams added to the course id in the most recent range (ordered in desc) where probably exams have been added more recently is appearing before the older ones with the lower course ids.