### PR TITLE
sets HTTP headers with user information to facilitate Safe Exam Browser's proctoring capabilities when student accessing attempt page

### DIFF
--- a/rule.php
+++ b/rule.php
@@ -639,6 +639,25 @@ class quizaccess_sebserver extends access_rule_base {
         ];
     }
     /**
+     * Setup attempt page
+     *
+     * @param stdClass page
+     * set header earlier so that Safe Exam Browser can detect proctoring using SAML2 method of login
+     */
+    
+    public function setup_attempt_page($page) {
+        global $USER;
+
+        // Force session init or preload
+        if (isloggedin() && !isguestuser()) {
+                // You could log this or preload something
+                header("X-LMS-USER-ID: $USER->id");
+                header("X-LMS-USER-USERNAME: $USER->username");
+                header("X-LMS-USER-EMAIL: $USER->email");
+                header("X-LMS-USER-IDNUMBER: $USER->idnumber");
+        }
+    }
+    /**
      * Calls Rest API of SebServer.
      *
      * @param string $url end point.


### PR DESCRIPTION
This pull request introduces a new method to the `rule.php` file to enhance the setup of the attempt page for quizzes. The key addition is the `setup_attempt_page` method, which sets HTTP headers with user information to facilitate Safe Exam Browser's proctoring capabilities.

### Enhancements for Safe Exam Browser integration:
* [`rule.php`](diffhunk://#diff-46982b177d48791b7d8c2bd50e54e4dcfe70642870f2e5a13de184f3ceba7e49R641-R659): Added the `setup_attempt_page` method, which initializes session data and sets HTTP headers (`X-LMS-USER-*`) with user details (e.g., ID, username, email) for logged-in users. This allows Safe Exam Browser to detect proctoring using the SAML2 login method.